### PR TITLE
chore(deps): delete stale chart oauth2-proxy-valkey in chorus-build

### DIFF
--- a/chorus-build/oauth2-proxy-valkey/README.md
+++ b/chorus-build/oauth2-proxy-valkey/README.md
@@ -1,7 +1,0 @@
-# Oauth2-proxy Valkey
-
-## Why
-
-`oauth2-proxy` will be used to secure various bits of the infrastructure, such as, Prometheus or Alertmanager, that don't come with out of the box solution. Since we're using Keycloak, storing the credentials in the cookie is not good enough, hence that credential must be stored somewhere.
-
-See: <https://oauth2-proxy.github.io/oauth2-proxy/configuration/session_storage/#redis-storage>

--- a/chorus-build/oauth2-proxy-valkey/config.json
+++ b/chorus-build/oauth2-proxy-valkey/config.json
@@ -1,6 +1,0 @@
-{
-  "chart": "valkey",
-  "version": "0.0.8",
-  "namespace": "keycloak",
-  "stepName": "database"
-}

--- a/chorus-build/oauth2-proxy-valkey/values.yaml
+++ b/chorus-build/oauth2-proxy-valkey/values.yaml
@@ -1,7 +1,0 @@
-valkey:
-  auth:
-    enabled: true
-    sentinel: false
-
-    existingSecret: oauth2-proxy-valkey-secret
-    existingSecretPasswordKey: REDIS_PASSWORD


### PR DESCRIPTION
This PR deletes the stale chart folder **oauth2-proxy-valkey** in **chorus-build**